### PR TITLE
removes packageBinaries

### DIFF
--- a/package/x86_64/WindowsServer_2016/package.ps1
+++ b/package/x86_64/WindowsServer_2016/package.ps1
@@ -7,20 +7,5 @@ function buildReqExec
   python -m PyInstaller --clean --hidden-import=requests -F main.py
 }
 
-# TODO: move this to pipelines later
-function packageBinaries
-{
-  $bin_directory = ".\dist\main"
-  New-Item -ItemType Directory -Force -Path $bin_directory
-  Move-Item -force .\dist\main.exe $bin_directory
-  $tmpReqExecPath = "$Env:USERPROFILE/shippable/tmp/reqExec"
-  New-Item -ItemType Directory -Force -Path $tmpReqExecPath
-  Copy-Item -Force -Recurse dist $tmpReqExecPath/
-  tar -zcvf reqExec.tar.gz -C $tmpReqExecPath .
-}
-
 echo "building reqExec binaries"
 buildReqExec
-
-echo "compressing binaries"
-packageBinaries


### PR DESCRIPTION
https://github.com/Shippable/reqExec/issues/58

We will be moving the process of packaging the exe as zip file to `reqExec_x86_64_WindowsServer_2016_pack` runSh job in https://github.com/Shippable/x86_64.WindowsServer_2016.prep

So, it's safe to remove this from here. 