### PR TITLE
Remove length based console flushing

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -226,9 +226,6 @@ class Executor(object):
         with self._console_buffer_lock:
             self._console_buffer.append(console_out)
 
-        if len(self._console_buffer) > self._config['CONSOLE_BUFFER_LENGTH']:
-            self._flush_console_buffer()
-
     def _set_console_flush_timer(self):
         """
         Calls _flush_console_buffer to flush console buffers in constant


### PR DESCRIPTION
The length based console flushing runs on the script runner thread which affects builds with large output.
https://github.com/Shippable/reqExec/issues/79